### PR TITLE
fix: change prCreation from not-pending to immediate

### DIFF
--- a/pr.json
+++ b/pr.json
@@ -8,7 +8,7 @@
     "{{updateType}}",
     "{{manager}}"
   ],
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "rebaseWhen": "conflicted",
   "requireConfig": "required",
   "reviewers": ["damoun"]


### PR DESCRIPTION
## Summary
- Change `prCreation` from `"not-pending"` to `"immediate"` in `pr.json`
- Fixes the "awaiting pending status checks" issue on all Renovate dashboards (e.g. damoun/twitch_exporter#51)

## Problem
`not-pending` creates a chicken-and-egg problem: Renovate waits for status checks to pass before creating the PR, but checks only run when a PR exists. This causes updates to get stuck permanently in "Pending Status Checks".

## Test plan
- [ ] After merge, verify Renovate's next run moves items out of "Pending Status Checks" on damoun/twitch_exporter#51