### PR TITLE
ci: restrict validate workflow token to contents:read

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   find_renovate_config_files:
     name: Find Renovate configuration files


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `.github/workflows/validate.yaml`
- Resolves zizmor `excessive-permissions` code-scanning alerts (#3, #4, #5)

Refs #9

## Test plan
- [ ] CI validate workflow stays green
- [ ] After merge, code-scanning alerts #3/#4/#5 transition to `fixed`